### PR TITLE
fix typings definition for the request module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -223,6 +223,7 @@ declare namespace request {
      *   timeout option (the default in Linux can be anywhere from 20-120 seconds).
      */
     timeout?: number;
+    time?: boolean;
     proxy?: any;
     strictSSL?: boolean;
     gzip?: boolean;


### PR DESCRIPTION
with the request package (version 2.72) installed in my typescript project and compiling after installing the typings for it, I am getting these error:

```
Object literal may only specify known properties, and 'time' does not exist in type '(UriOptions | UrlOptions) & RequestPromiseOptions'.
error TS2345: Argument of type '{ method: string; url: string; qs: { api_key: string; }; headers: { [x: string]: string; 'Accept-...' is not assignable to parameter of type '(UriOptions | UrlOptions) & RequestPromiseOptions'.
```

Adding the time property is fixing it to the typings definition.

Thanks
